### PR TITLE
fixes #7: console_scripts file names now have the major python version appended for python3

### DIFF
--- a/testing/test_wheel2deb.py
+++ b/testing/test_wheel2deb.py
@@ -87,8 +87,12 @@ def test_conversion(tmp_path, wheel_path):
 
     package_hash = digests(package_list[0])
 
+    endpoint_python_version = ""
+    if sys.version_info[0] >= 3:
+        endpoint_python_version = str(sys.version_info[0])
+
     # check that the entrypoint will be installed in /usr/bin
-    entrypoint = (unpack_path / 'debian/python3-foobar/usr/bin/entrypoint')
+    entrypoint = (unpack_path / ('debian/python3-foobar/usr/bin/entrypoint'+endpoint_python_version))
     assert entrypoint.exists()
 
     # check shebang


### PR DESCRIPTION
See issue #7

Comment within the code explaining the change:

> Some python debian packages have separate python2 and python3 Debian packages released. If a package has a `console_scripts` entry, and the python2 version of a debian package is already installed, when we attempt to install a python3 package created by wheel2deb, it will fail because `apt` will not let it overwrite an existing file. An example of this is the `pyjwt` package: for the officially released Debian packages, this creates `/usr/bin/pyjwt` (`apt install python-jwt`) and `/usr/bin/pyjwt3` (`apt install python3-jwt`). The code below follows a similar pattern, by appending the python major version to `console_scripts` entries for versions three and above.