### PR TITLE
fixes #5: support for two digit versions or those that contain an asterisk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ images:
 check:
 	@flake8 src
 
-tests:
+tests: bdist
 	$(eval images := $(foreach a,$(DEBIAN_DISTS),$(IMAGE_NAME):$(a)))
 	$(call map,run_tests,$(images))
 

--- a/src/_wheel2deb/depends.py
+++ b/src/_wheel2deb/depends.py
@@ -140,7 +140,7 @@ def search_python_deps(ctx, wheel, extras=None):
 
         if req.name in ctx.ignore_specifiers:
             logger.warning('ignoring specifiers for dependency %s', req.name)
-            debian_deps.append(pdep, specifier.operator, specifier.version)
+            debian_deps.append(pdep)
         elif not ctx.ignore_upstream_versions and len(req.specifier):
             for specifier in req.specifier:
                 dep = get_dependency_string(pdep, specifier.operator, specifier.version)

--- a/testing/test_depends.py
+++ b/testing/test_depends.py
@@ -1,4 +1,4 @@
-from _wheel2deb.depends import suggest_name, search_python_deps
+from _wheel2deb.depends import suggest_name, search_python_deps, get_dependency_string
 from _wheel2deb.context import Context
 from _wheel2deb.pyvers import Version
 from _wheel2deb.pydist import Wheel
@@ -23,3 +23,22 @@ def test_search_python_deps(wheel_path):
 
     assert deps[0].startswith('python3-py (>= 0.1')
     assert not missing_deps
+
+def test_get_dependency_string():
+    assert get_dependency_string("python3-py", "==", "1.2.3") == "python3-py (<< 1.3)"
+    assert get_dependency_string("python3-py", "==", "1.2.*") == "python3-py (<< 1.3)"
+    assert get_dependency_string("python3-py", "==", "1.2") == "python3-py (<< 1.3)"
+    assert get_dependency_string("python3-py", "==", "1.*") == "python3-py (<< 2)"
+    assert get_dependency_string("python3-py", "==", "1") == "python3-py (<< 2)"
+
+    assert get_dependency_string("python3-py", ">=", "1.2.3") == "python3-py (>= 1.2.3)"
+    assert get_dependency_string("python3-py", ">=", "1.2.*") == "python3-py (>= 1.2)"
+    assert get_dependency_string("python3-py", ">=", "1.2") == "python3-py (>= 1.2)"
+    assert get_dependency_string("python3-py", ">=", "1.*") == "python3-py (>= 1)"
+    assert get_dependency_string("python3-py", ">=", "1") == "python3-py (>= 1)"
+
+    assert get_dependency_string("python3-py", "<=", "1.2.3") == "python3-py (<= 1.2.3-+)"
+    assert get_dependency_string("python3-py", "<=", "1.2.*") == "python3-py (<= 1.2-+)"
+    assert get_dependency_string("python3-py", "<=", "1.2") == "python3-py (<= 1.2-+)"
+    assert get_dependency_string("python3-py", "<=", "1.*") == "python3-py (<= 1-+)"
+    assert get_dependency_string("python3-py", "<=", "1") == "python3-py (<= 1-+)"


### PR DESCRIPTION
For a real-world test of what this fixes, attempt to process "uvicorn==0.11.1"