### PR TITLE
Avoid stripping symbols from binaries

### DIFF
--- a/src/_wheel2deb/templates/rules.j2
+++ b/src/_wheel2deb/templates/rules.j2
@@ -5,3 +5,6 @@
 
 override_dh_shlibdeps:
 	true
+
+override_dh_strip:
+	dh_strip --exclude=/site-packages/ --exclude=/dist-packages/


### PR DESCRIPTION
Many python packages provide C-level bindings to low level libraries.
During the Debian package build process, dh_strip is called to remove
unnecessary symbols. But it cannot know that they are not actually
referenced in other binaries, but only called by the python package
during runtime.
This prevents stripping critical symbols that are used by such python
packages.