### PR TITLE
Cast content of the --python-version argument from str to Version.

### DIFF
--- a/src/_wheel2deb/context.py
+++ b/src/_wheel2deb/context.py
@@ -38,6 +38,8 @@ class Context:
     def update(self, changes):
         for k, v in changes.items():
             if v and hasattr(self, k):
+                if k == "python_version":
+                    changes[k] = Version.from_str(v) if isinstance(v, str) else v
                 setattr(self, k, changes[k])
 
 


### PR DESCRIPTION
Fix #20
The `python_version` member of the Context class gets initialized as `Version` but
if the user passes the `--python-version` argument, then it gets converted to string.
This makes `wheel2deb` crash. See linked issue for more details.