### PR TITLE
Fix --ignore-upstream-version(s) commandline option

### DIFF
--- a/src/wheel2deb.py
+++ b/src/wheel2deb.py
@@ -59,7 +59,7 @@ def parse_args(argv):
         help="Don't include entry points in debian package",
     )
     p.add_argument(
-        "--ignore-upstream-version",
+        "--ignore-upstream-versions",
         action="store_true",
         help="Ignore version specifiers from wheel requirements",
     )


### PR DESCRIPTION
The names on the `Context` object and provided to the argument parser
do not match; because the `Context.update` method silently ignores
unknown attributes, the option is accepted but never really used at
runtime.