### PR TITLE
python_version is converted on each attribute assignment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ wheel
 pkginfo
 jinja2
 colorama
-attrs>=17
+attrs>=20.1
 packaging
 pyyaml
 dirsync

--- a/src/_wheel2deb/context.py
+++ b/src/_wheel2deb/context.py
@@ -13,6 +13,7 @@ class Context:
     distribution = attr.ib(default="unstable")
     python_version = attr.ib(
         converter=lambda x: Version.from_str(x) if isinstance(x, str) else x,
+        on_setattr=attr.setters.convert,
         default=platform.python_version(),
     )
     platform_machine = attr.ib(default=platform.machine())


### PR DESCRIPTION
Fix: Argument --python-version is broken

resolves https://github.com/upciti/wheel2deb/issues/20
python_version value is converted on each assignment by changing on_setattr argument of the attribute. This feature is available since attr package version 20.1.0.

The solution should be attributed to @SpringbokBE as he suggested this approach in #22 .