### PR TITLE
Update pyproject.toml to work with python 3.11 or greater

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.11"
+python = ">=3.10"
 typer = ">=0.6.1"
 wheel = "*"
 pkginfo = "*"


### PR DESCRIPTION
Currently it installs 0.5.8 if python3.11 is installed (as currently on debian sid). Is there a reason for the upper limit?