### PR TITLE
Find correct package for pyyaml and simular packages

### DIFF
--- a/src/wheel2deb/depends.py
+++ b/src/wheel2deb/depends.py
@@ -70,6 +70,8 @@ def suggest_name(ctx, wheel_name):
 def suggest_names(ctx, wheel_names):
     for wheel_name in wheel_names:
         yield suggest_name(ctx, wheel_name)
+        if wheel_name[:2] == "py":
+            yield suggest_name(ctx, wheel_name[2:])
 
 
 def search_python_deps(ctx, wheel, extras=None):


### PR DESCRIPTION
In the debian sources, some packages, which are prepended with py e.g.: pyyaml have the py stripped (pyyaml -> python3-yaml). This PR tries to account for such situations.