### PR TITLE
fix: catch version errors and continue

### DIFF
--- a/src/wheel2deb/depends.py
+++ b/src/wheel2deb/depends.py
@@ -123,13 +123,17 @@ def search_python_deps(ctx, wheel, extras=None):
     for pdep, req in zip(debnames, requirements):
 
         def check(x):
-            if req.specifier.contains(x.version, prereleases=True):
-                logger.info(f"{x} satisfies requirement {req}")
-            else:
-                logger.warning(f"{x} does not satisfy requirement {req}")
-            return ctx.ignore_upstream_versions or req.specifier.contains(
-                x.version, prereleases=True
-            )
+            try:
+                if req.specifier.contains(x.version, prereleases=True):
+                    logger.info(f"{x} satisfies requirement {req}")
+                else:
+                    logger.warning(f"{x} does not satisfy requirement {req}")
+                return ctx.ignore_upstream_versions or req.specifier.contains(
+                    x.version, prereleases=True
+                )
+            except Exception as e:
+                logger.warning(f"{x} does not satisfy requirement: {e}")
+                return False
 
         version = None
         for candidate in candidates[req.name]:


### PR DESCRIPTION
Any invalid version in the debian repository can cause wheel2deb to crash and not continue searching for a valid version.

Example: a package with a version of '0.8.0~rc3' causes wheel2deb to crash. We should at least continue to investigate other packages in the repository.

This pull request adds a try catch and logging of the error.